### PR TITLE
Had to make some changes when setting up the project for the first ti…

### DIFF
--- a/db/migrate/20171204184648_create_doorkeeper_tables.rb
+++ b/db/migrate/20171204184648_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[5.0]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180703215754) do
+ActiveRecord::Schema.define(version: 2018_07_03_215754) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -180,6 +180,7 @@ ActiveRecord::Schema.define(version: 20180703215754) do
     t.datetime "created_at", null: false
     t.datetime "revoked_at"
     t.string "scopes"
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
     t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
   end
 
@@ -193,6 +194,7 @@ ActiveRecord::Schema.define(version: 20180703215754) do
     t.datetime "created_at", null: false
     t.string "scopes"
     t.string "previous_refresh_token", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
     t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
     t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
     t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: 99)
 
 member = Member.create(
   first_name: 'Mario',
@@ -8,7 +7,6 @@ member = Member.create(
   birthday: 35.years.ago,
   email: "mario@bros.com",
   phone1: "4911111111",
-  password: "123456",
   password_confirmation: "123456"
 )
 
@@ -65,4 +63,4 @@ QuestionOption.create(
   title: "No",
   position: 1
 )
-AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?
+AdminUser.create!(email: 'admin1@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?


### PR DESCRIPTION
Had to make some changes when setting up the project for the first time. The changes are in two parts

1. create_doorkeeper_tables migration script did not have the 5.0 so this step broke bundle exec rake db:migrate
2. seeds.rb expects Members.create to contain a password field which is not part of the model

Changes not accounted for:
1. schemas.rb added a new index application_id on table active_admin_comments when db:migrate was executed.