### PR TITLE
Allow to create an attendee

### DIFF
--- a/app/admin/attendee.rb
+++ b/app/admin/attendee.rb
@@ -35,4 +35,12 @@ ActiveAdmin.register Attendee do
       end
     end
   end
+
+  permit_params :member_id,
+                :event_instance_id,
+                :form_reply,
+                :canceled,
+                :paid,
+                :comment,
+                :terms_accepted
 end


### PR DESCRIPTION
I was testing the admin tool and noticed that it was generating an error when I was manually creating an attendee.